### PR TITLE
Additional configure checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,9 @@ AC_CHECK_HEADERS([gc_hal_driver.h gc_hal_kernel_buffer.h],
                  [],
                  [AC_MSG_ERROR([required libGAL header file missing])],
                  [#include <gc_hal.h>])
+AC_CHECK_HEADERS([gc_abi.h],
+                 [],
+                 [AC_MSG_ERROR([required galcore_headers file missing])])
 CPPFLAGS="$saved_CPPFLAGS"
 
 AC_SUBST([GALCORE_CFLAGS])

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,13 @@ AC_CHECK_HEADERS([gc_abi.h],
                  [AC_MSG_ERROR([required galcore_headers file missing])])
 CPPFLAGS="$saved_CPPFLAGS"
 
+saved_LDFLAGS="$LDFLAGS"
+LDFLAGS="$LDFLAGS $GALCORE_LIBS"
+AC_CHECK_LIB([GAL],[gco3D_WriteBuffer],
+             [],
+             [AC_MSG_ERROR([required libGAL missing])])
+LDFLAGS="$saved_LDFLAGS"
+
 AC_SUBST([GALCORE_CFLAGS])
 AC_SUBST([GALCORE_LIBS])
 


### PR DESCRIPTION
Check for gc_abi.h and ilbGAL.so upfront. 

gc_abi.h is the only file not from vivante but we need it to build. Checking for libGAL.so detects an incorrect 
-with-galcore-lib earlier.

Just cosmetics to make the initial setup a bit simpler.