### PR TITLE
Check for libGAL-wl.so too

### DIFF
--- a/src/viv_hook.c
+++ b/src/viv_hook.c
@@ -428,7 +428,7 @@ void the_hook(const char *filename)
 {
     char *mali_path = NULL; // path to libMali.so
     void *mali_base = NULL;
-    char *gal_names[] = {"libGAL.so", "libGAL-fb.so", 0};
+    char *gal_names[] = {"libGAL.so", "libGAL-fb.so", "libGAL-wl.so", NULL};
 
     hook_start_logging(filename);
 


### PR DESCRIPTION
This is the libGAL for wayland and the one shipped by default in NXPs
4.14 image. It's named libGAL.so in the image but when one builds
development environment to link against it the symlinks woult point to
libGAL-wl.so.