### PR TITLE
Draft: v6.4.3.p4.6 support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,50 @@
+project('libvivhook',
+	'c', 'cpp',
+	version: '1.0.0',
+	license: 'MIT',
+	default_options: [
+		'c_std=gnu99',
+	],
+)
+
+cc = meson.get_compiler('c')
+add_project_arguments(cc.get_supported_arguments([
+		'-feliminate-unused-debug-types',
+		'-Wnested-externs',
+		'-Wcast-qual',
+		'-Wredundant-decls',
+		'-Werror=write-strings',
+		'-Wshadow',
+]), language: ['c'])
+
+add_project_arguments([
+	'-D_GNU_SOURCE',
+], language: 'c')
+
+dl = cc.find_library('dl', required: true)
+galcore = declare_dependency(
+	include_directories: include_directories(get_option('galcore-include')),
+	link_args: ['-L'+ get_option('galcore-lib'), '-lGAL'],
+)
+
+vivhook_src = files(
+	'src/elf_hook.c',
+	'src/flightrecorder.cpp',
+	'src/viv_hook.c',
+)
+
+libvivhook = library('vivhook',
+	vivhook_src,
+	dependencies: [dl, galcore],
+)
+
+viv_interpose_src = vivhook_src + files(
+	'src/viv_interpose.c',
+)
+
+viv_interpose = shared_library('viv_interpose',
+	viv_interpose_src,
+	name_prefix: '',
+	dependencies: [dl, galcore],
+)
+

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('galcore-include', type: 'string')
+option('galcore-lib', type: 'string')


### PR DESCRIPTION
Requires https://github.com/etnaviv/galcore_headers/pull/3 

Compiles but segfaults in `libGAL.so`

```
Program received signal SIGSEGV, Segmentation fault.
0x0000fffff71efeb8 in gcoOS_GetTLS () from /usr/lib/libGAL.so
(gdb) bt
#0  0x0000fffff71efeb8 in gcoOS_GetTLS () from /usr/lib/libGAL.so
#1  0x0000fffff7097540 in gcoHAL_SetHardwareType () from /usr/lib/libGAL.so
#2  0x0000fffff7252da4 in ?? () from /usr/lib/libgbm_viv.so
#3  0x0000fffff7253010 in gbm_viv_create_buffers () from /usr/lib/libgbm_viv.so
#4  0x0000fffff72532ac in ?? () from /usr/lib/libgbm_viv.so
#5  0x0000000000405640 in init_surface (modifier=<optimized out>, modifier@entry=0) at ../common.c:96
#6  0x0000000000405c1c in init_gbm (drm_fd=<optimized out>, w=1920, h=1080, format=format@entry=875713112, modifier=modifier@entry=0, 
    surfaceless=surfaceless@entry=false) at ../common.c:139
#7  0x000000000040bf60 in main (argc=<optimized out>, argv=<optimized out>) at ../kmscube.c:229
```

Builds on #4 